### PR TITLE
Curation status removal

### DIFF
--- a/app/api/app.py
+++ b/app/api/app.py
@@ -614,7 +614,7 @@ async def upload_csv(file: UploadFile = File(...)):
                         "reason_if_missing": "explanation if absent",
                         "suggestions_for_curation": "what additional info is needed"
                     }},
-                    "curation_ready": true/false,
+
                     "missing_fields": ["field1", "field2", ...],
                     "curation_preparation_summary": "Overall assessment of what's needed for curation"
                 }}
@@ -654,14 +654,7 @@ async def upload_csv(file: UploadFile = File(...)):
                             elif field == "sample_size":
                                 parsed_analysis[field] = {"size": "Unknown", "confidence": 0.0, "status": "ABSENT", "reason_if_missing": "Field not found in analysis", "suggestions_for_curation": "Review paper for sample size information"}
                     
-                    # Determine curation readiness based on having all 6 fields with status "PRESENT"
-                    curation_ready = len(missing_fields) == 0 and all(
-                        parsed_analysis.get(field, {}).get("status") == "PRESENT" 
-                        for field in required_fields
-                    )
-                    
-                    # Update the parsed analysis with curation readiness
-                    parsed_analysis["curation_ready"] = curation_ready
+                    # Update the parsed analysis with missing fields
                     parsed_analysis["missing_fields"] = missing_fields
                     
                 except json.JSONDecodeError:
@@ -673,7 +666,6 @@ async def upload_csv(file: UploadFile = File(...)):
                         "sequencing_type": {"method": "Unknown", "confidence": 0.0, "status": "ABSENT", "reason_if_missing": "JSON parsing failed", "suggestions_for_curation": "Re-run analysis"},
                         "taxa_level": {"level": "Unknown", "confidence": 0.0, "status": "ABSENT", "reason_if_missing": "JSON parsing failed", "suggestions_for_curation": "Re-run analysis"},
                         "sample_size": {"size": "Unknown", "confidence": 0.0, "status": "ABSENT", "reason_if_missing": "JSON parsing failed", "suggestions_for_curation": "Re-run analysis"},
-                        "curation_ready": False,
                         "missing_fields": ["host_species", "body_site", "condition", "sequencing_type", "taxa_level", "sample_size"],
                         "curation_preparation_summary": "Analysis failed - re-run required"
                     }
@@ -685,14 +677,13 @@ async def upload_csv(file: UploadFile = File(...)):
                     metadata, 
                     "gemini_enhanced", 
                     analysis.get("confidence", 0.0), 
-                    curation_ready
+                    False
                 )
                 
                 results.append({
                     "pmid": pmid,
                     "title": metadata.get("title", ""),
-                    "enhanced_analysis": parsed_analysis,
-                    "curation_ready": curation_ready
+                    "enhanced_analysis": parsed_analysis
                 })
                 
             except Exception as e:
@@ -760,7 +751,7 @@ async def analyze_paper(pmid: str, request: Request):
     
     **Returns:**
     - **enhanced_analysis**: Detailed analysis of the 6 essential fields
-    - **curation_ready**: Boolean indicating if the paper is ready for curation
+    
     - **metadata**: Paper metadata (title, abstract, authors, etc.)
     
     **6 Essential Fields Analyzed:**
@@ -805,7 +796,7 @@ async def analyze_paper(pmid: str, request: Request):
                 "pmid": pmid,
                 "metadata": cached_result["metadata"],
                 "enhanced_analysis": cached_result["analysis_data"],
-                "curation_ready": cached_result["curation_ready"],
+
                 "timestamp": cached_result["timestamp"],
                 "source": cached_result["source"],
                 "cached": True
@@ -1224,7 +1215,7 @@ async def analyze_batch(pmids: list = Body(...), page: int = Query(1), page_size
     **Returns:**
     - List of analysis results, each containing:
         - **enhanced_analysis**: 6-field analysis results
-        - **curation_ready**: Boolean indicating curation readiness
+        
         - **metadata**: Paper metadata
         - **status**: Success/error status
     
@@ -1244,7 +1235,6 @@ async def analyze_batch(pmids: list = Body(...), page: int = Query(1), page_size
                     "pmid": pmid,
                     "metadata": cached_result["metadata"],
                     "enhanced_analysis": cached_result["analysis_data"],
-                    "curation_ready": cached_result["curation_ready"],
                     "timestamp": cached_result["timestamp"],
                     "source": cached_result["source"],
                     "cached": True,
@@ -1360,7 +1350,6 @@ async def analyze_batch(pmids: list = Body(...), page: int = Query(1), page_size
                     "reason_if_missing": "explanation if absent",
                     "suggestions_for_curation": "what additional info is needed"
                 }},
-                "curation_ready": true/false,
                 "missing_fields": ["field1", "field2", ...],
                 "curation_preparation_summary": "Overall assessment of what's needed for curation"
             }}
@@ -1627,7 +1616,6 @@ async def enhanced_analysis(pmid: str):
     
     **Returns:**
     - **enhanced_analysis**: Detailed analysis of the 6 essential fields
-    - **curation_ready**: Boolean indicating if the paper is ready for curation
     - **metadata**: Paper metadata (title, abstract, authors, etc.)
     - **cached**: Boolean indicating if result was retrieved from cache
     
@@ -1652,7 +1640,6 @@ async def enhanced_analysis(pmid: str):
                 "pmid": pmid,
                 "metadata": cached_result["metadata"],
                 "enhanced_analysis": cached_result["analysis_data"],
-                "curation_ready": cached_result["curation_ready"],
                 "timestamp": cached_result["timestamp"],
                 "source": cached_result["source"],
                 "cached": True
@@ -1940,7 +1927,6 @@ async def enhanced_analysis_batch(pmids: List[str] = Body(...), max_concurrent: 
                         "pmid": pmid,
                         "metadata": cached_result["metadata"],
                         "enhanced_analysis": cached_result["analysis_data"],
-                        "curation_ready": cached_result["curation_ready"],
                         "timestamp": cached_result["timestamp"],
                         "source": cached_result["source"],
                         "cached": True,
@@ -2056,7 +2042,7 @@ async def enhanced_analysis_batch(pmids: List[str] = Body(...), max_concurrent: 
                             "reason_if_missing": "explanation if absent",
                             "suggestions_for_curation": "what additional info is needed"
                         }},
-                        "curation_ready": true/false,
+        
                         "missing_fields": ["field1", "field2", ...],
                         "curation_preparation_summary": "Overall assessment of what's needed for curation"
                     }}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>BioAnalyzer - BugSigDB Curation Analysis</title>
+    <title>BioAnalyzer - BugSigDB Analysis</title>
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🧬</text></svg>">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
@@ -196,7 +196,7 @@
                         <h1 class="mb-2">
                             <i class="fas fa-microscope me-3"></i>BioAnalyzer
                         </h1>
-                        <p class="mb-0 fs-5 opacity-75">BugSigDB Curation Analysis System</p>
+                        <p class="mb-0 fs-5 opacity-75">BugSigDB Analysis System</p>
                     </div>
 
                 </div>
@@ -267,8 +267,8 @@
                         
                         <!-- Single Analyze Button -->
                         <div class="text-center mt-4">
-                            <button class="btn analyze-button btn-lg" onclick="window.analyzeForCuration ? analyzeForCuration() : alert('Please wait for the page to fully load')">
-                                <i class="fas fa-microscope me-2"></i>Analyze for Curation
+                            <button class="btn analyze-button btn-lg" onclick="window.analyzePapers ? analyzePapers() : alert('Please wait for the page to fully load')">
+                                <i class="fas fa-microscope me-2"></i>Analyze Papers
                             </button>
                         </div>
                     </div>
@@ -280,7 +280,7 @@
                             <div class="spinner-border text-primary" style="width: 3rem; height: 3rem;" role="status">
                                 <span class="visually-hidden">Loading...</span>
                             </div>
-                            <p class="mt-3 fs-5">Analyzing papers for BugSigDB curation readiness...</p>
+                            <p class="mt-3 fs-5">Analyzing papers for BugSigDB requirements...</p>
                             <p class="text-muted">This may take a few moments</p>
                         </div>
                         
@@ -288,7 +288,7 @@
                         <div class="empty-state" id="empty-state">
                             <i class="fas fa-chart-bar"></i>
                             <h4>Ready for Analysis</h4>
-                            <p class="fs-5">Enter a PMID, upload a file, or provide a list of PMIDs above, then click "Analyze for Curation" to begin.</p>
+                            <p class="fs-5">Enter a PMID, upload a file, or provide a list of PMIDs above, then click "Analyze Papers" to begin.</p>
                             <p class="text-muted">The system will analyze the 6 essential fields: Host Species, Body Site, Condition, Sequencing Type, Taxa Level, and Sample Size.</p>
                         </div>
                         

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -4,7 +4,7 @@ window.ws = null;
 window.isConnected = false;
 
 // Immediately define the function globally
-window.analyzeForCuration = async function() {
+window.analyzePapers = async function() {
     
     const fileInput = document.getElementById('fileInput');
     const singlePmid = document.getElementById('singlePmid').value.trim();
@@ -371,32 +371,23 @@ function displayResults(results) {
                     <i class="fas fa-trash me-2"></i>Clear
                 </button>
             </div>
-            </div>
+        </div>
         
         <div class="row">
-            <div class="col-md-6">
+            <div class="col-md-12">
                 <div class="card bg-light">
                     <div class="card-body text-center">
                         <h5 class="card-title">Papers Analyzed</h5>
                         <h2 class="text-primary">${results.length}</h2>
-                </div>
                     </div>
-                    </div>
-            <div class="col-md-6">
-                <div class="card bg-light">
-                    <div class="card-body text-center">
-                        <h5 class="card-title">Ready for Curation</h5>
-                        <h2 class="text-success">${results.filter(r => r.enhanced_analysis?.curation_ready).length}</h2>
-            </div>
-            </div>
                 </div>
             </div>
+        </div>
         `;
         
     // Add individual paper results
     results.forEach((result, index) => {
         const analysis = result.enhanced_analysis || {};
-        const curationReady = analysis.curation_ready ? 'Yes' : 'No';
         
         resultsHTML += `
             <div class="card mt-3">
@@ -404,9 +395,6 @@ function displayResults(results) {
                     <h6 class="mb-0">
                         <strong>PMID ${result.pmid}</strong> - ${result.title || 'N/A'}
                     </h6>
-                    <span class="badge ${analysis.curation_ready ? 'bg-success' : 'bg-warning'}">
-                        Curation Ready: ${curationReady}
-                    </span>
                 </div>
                 <div class="card-body">
                     <div class="row">
@@ -416,16 +404,16 @@ function displayResults(results) {
                                 <p class="mb-1"><strong>Value:</strong> ${analysis.host_species?.primary || 'Unknown'}</p>
                                 <p class="mb-1"><strong>Status:</strong> <span class="status-${analysis.host_species?.status?.toLowerCase() || 'absent'}">${analysis.host_species?.status || 'ABSENT'}</span></p>
                                 <p class="mb-1"><strong>Confidence:</strong> ${(analysis.host_species?.confidence || 0).toFixed(2)}</p>
-                </div>
-                </div>
+                            </div>
+                        </div>
                         <div class="col-md-6">
                             <div class="field-card">
                                 <h6><i class="fas fa-map-marker-alt me-2"></i>Body Site</h6>
                                 <p class="mb-1"><strong>Value:</strong> ${analysis.body_site?.site || 'Unknown'}</p>
                                 <p class="mb-1"><strong>Status:</strong> <span class="status-${analysis.body_site?.status?.toLowerCase() || 'absent'}">${analysis.body_site?.status || 'ABSENT'}</span></p>
                                 <p class="mb-1"><strong>Confidence:</strong> ${(analysis.body_site?.confidence || 0).toFixed(2)}</p>
-            </div>
-                </div>
+                            </div>
+                        </div>
                     </div>
                     <div class="row">
                         <div class="col-md-6">
@@ -434,15 +422,15 @@ function displayResults(results) {
                                 <p class="mb-1"><strong>Value:</strong> ${analysis.condition?.description || 'Unknown'}</p>
                                 <p class="mb-1"><strong>Status:</strong> <span class="status-${analysis.condition?.status?.toLowerCase() || 'absent'}">${analysis.condition?.status || 'ABSENT'}</span></p>
                                 <p class="mb-1"><strong>Confidence:</strong> ${(analysis.condition?.confidence || 0).toFixed(2)}</p>
-                </div>
-                    </div>
+                            </div>
+                        </div>
                         <div class="col-md-6">
                             <div class="field-card">
                                 <h6><i class="fas fa-microscope me-2"></i>Sequencing Type</h6>
                                 <p class="mb-1"><strong>Value:</strong> ${analysis.sequencing_type?.method || 'Unknown'}</p>
                                 <p class="mb-1"><strong>Status:</strong> <span class="status-${analysis.condition?.status?.toLowerCase() || 'absent'}">${analysis.sequencing_type?.status || 'ABSENT'}</span></p>
                                 <p class="mb-1"><strong>Confidence:</strong> ${(analysis.sequencing_type?.confidence || 0).toFixed(2)}</p>
-                </div>
+                            </div>
                         </div>
                     </div>
                     <div class="row">
@@ -460,8 +448,8 @@ function displayResults(results) {
                                 <p class="mb-1"><strong>Value:</strong> ${analysis.sample_size?.size || 'Unknown'}</p>
                                 <p class="mb-1"><strong>Status:</strong> <span class="status-${analysis.sample_size?.status?.toLowerCase() || 'absent'}">${analysis.sample_size?.status || 'ABSENT'}</span></p>
                                 <p class="mb-1"><strong>Confidence:</strong> ${(analysis.sample_size?.confidence || 0).toFixed(2)}</p>
-                    </div>
-                </div>
+                            </div>
+                        </div>
             </div>
             
                     ${analysis.missing_fields && analysis.missing_fields.length > 0 ? `
@@ -520,8 +508,8 @@ window.clearResults = function() {
 };
 
 // Legacy functions for backward compatibility (can be removed later)
-window.analyzeSinglePaper = window.analyzeForCuration;
-window.analyzeBatchPapers = window.analyzeForCuration;
+window.analyzeSinglePaper = window.analyzePapers;
+window.analyzeBatchPapers = window.analyzePapers;
 
     // Chat helper functions
     function handleChatKeyPress(event) {

--- a/frontend/js/curation-analysis.js
+++ b/frontend/js/curation-analysis.js
@@ -1,33 +1,33 @@
-// Enhanced Curation Analysis Display Functions
+// Enhanced Analysis Display Functions
 
-function displayEnhancedCurationAnalysis(curationAnalysis) {
-    if (!curationAnalysis) {
-        console.warn('No curation analysis data provided');
+function displayEnhancedAnalysis(analysisData) {
+    if (!analysisData) {
+        console.warn('No analysis data provided');
         return;
     }
 
-    // Display curation readiness status
-    displayCurationReadinessStatus(curationAnalysis.readiness, curationAnalysis.explanation);
+    // Display analysis status
+    displayAnalysisStatus(analysisData.status, analysisData.explanation);
     
-    // Display detailed explanation
-    displayCurationExplanation(curationAnalysis.explanation);
+    // Display analysis explanation
+    displayAnalysisExplanation(analysisData.explanation);
     
     // Display microbial signature analysis
-    displayMicrobialSignatureAnalysis(curationAnalysis);
+    displayMicrobialSignatureAnalysis(analysisData);
     
     // Display specific reasons
-    displaySpecificReasons(curationAnalysis.specific_reasons);
+    displaySpecificReasons(analysisData.specific_reasons);
     
     // Display examples and evidence
-    displayExamplesAndEvidence(curationAnalysis.examples);
+    displayExamplesAndEvidence(analysisData.examples);
     
     // Display missing fields if any
-    displayMissingFields(curationAnalysis.missing_fields);
+    displayMissingFields(analysisData.missing_fields);
 }
 
-function displayCurationReadinessStatus(readiness, explanation) {
-    const statusElement = document.getElementById('curation-readiness-status');
-    const textElement = document.getElementById('curation-readiness-text');
+function displayAnalysisStatus(status, explanation) {
+    const statusElement = document.getElementById('analysis-status');
+    const textElement = document.getElementById('analysis-status-text');
     
     if (!statusElement || !textElement) return;
     
@@ -37,11 +37,11 @@ function displayCurationReadinessStatus(readiness, explanation) {
     switch (readiness) {
         case 'READY':
             statusElement.classList.add('alert-success');
-            textElement.innerHTML = '<strong>READY FOR CURATION</strong> - This paper contains curatable microbial signatures and meets BugSigDB requirements.';
+            textElement.innerHTML = '<strong>ANALYSIS COMPLETE</strong> - This paper has been successfully analyzed for BugSigDB requirements.';
             break;
         case 'NOT_READY':
             statusElement.classList.add('alert-warning');
-            textElement.innerHTML = '<strong>NOT READY FOR CURATION</strong> - This paper lacks required elements for BugSigDB curation.';
+            textElement.innerHTML = '<strong>ANALYSIS COMPLETE</strong> - This paper has been analyzed but requires additional review.';
             break;
         case 'ERROR':
             statusElement.classList.add('alert-danger');
@@ -53,8 +53,8 @@ function displayCurationReadinessStatus(readiness, explanation) {
     }
 }
 
-function displayCurationExplanation(explanation) {
-    const element = document.getElementById('curation-explanation-text');
+function displayAnalysisExplanation(explanation) {
+    const element = document.getElementById('analysis-explanation-text');
     if (element) {
         element.textContent = explanation || 'No detailed explanation available.';
     }
@@ -251,11 +251,11 @@ function getCompletenessColorClass(completeness) {
     }
 }
 
-// Function to clear curation analysis display
-function clearCurationAnalysis() {
+// Function to clear analysis display
+function clearAnalysis() {
     const elements = [
-        'curation-readiness-text',
-        'curation-explanation-text',
+        'analysis-status-text',
+        'analysis-explanation-text',
         'microbial-signatures',
         'data-quality',
         'statistical-significance',
@@ -286,12 +286,12 @@ function clearCurationAnalysis() {
     }
     
     // Reset status alert
-    const statusElement = document.getElementById('curation-readiness-status');
+    const statusElement = document.getElementById('analysis-status');
     if (statusElement) {
         statusElement.className = 'alert alert-info';
     }
 }
 
 // Export functions for use in main app.js
-window.displayEnhancedCurationAnalysis = displayEnhancedCurationAnalysis;
-window.clearCurationAnalysis = clearCurationAnalysis; 
+window.displayEnhancedAnalysis = displayEnhancedAnalysis;
+window.clearAnalysis = clearAnalysis; 

--- a/frontend/paper-details.html
+++ b/frontend/paper-details.html
@@ -582,7 +582,7 @@
                     </button>
                 </div>
                 <h1><i class="fas fa-file-medical me-3"></i>Paper Details</h1>
-                <div class="subtitle">Comprehensive analysis and curation assessment</div>
+                <div class="subtitle">Comprehensive analysis and assessment</div>
             </div>
         </div>
 
@@ -617,19 +617,19 @@
                     <p id="abstract-content"></p>
                 </div>
 
-                <!-- Curation Status Section -->
+                <!-- Analysis Status Section -->
                 <div class="content-section">
-                    <h2><i class="fas fa-clipboard-check"></i>Curation Status</h2>
-                    <div id="curation-status-content">
-                        <!-- Curation status will be populated here -->
+                    <h2><i class="fas fa-clipboard-check"></i>Analysis Status</h2>
+                    <div id="analysis-status-content">
+                        <!-- Analysis status will be populated here -->
                     </div>
                 </div>
 
-                <!-- Enhanced Curation Analysis Section -->
-                <div id="curation-analysis-section" class="content-section" style="display: none;">
-                    <h2><i class="fas fa-microscope"></i>Enhanced Curation Analysis</h2>
-                    <div id="curation-analysis-content">
-                        <!-- Enhanced curation analysis will be populated here -->
+                <!-- Enhanced Analysis Section -->
+                <div id="enhanced-analysis-section" class="content-section" style="display: none;">
+                    <h2><i class="fas fa-microscope"></i>Enhanced Analysis</h2>
+                    <div id="enhanced-analysis-content">
+                        <!-- Enhanced analysis will be populated here -->
                     </div>
                 </div>
 
@@ -752,9 +752,9 @@
             `).join('');
         }
 
-        // Populate curation status
-        function populateCurationStatus(data) {
-            const statusContent = document.getElementById('curation-status-content');
+        // Populate analysis status
+        function populateAnalysisStatus(data) {
+            const statusContent = document.getElementById('analysis-status-content');
             const metadata = data.metadata || {};
 
             const statusBadgeClass = getStatusBadgeClass(data.curation_status_message);
@@ -771,9 +771,9 @@
             `;
         }
 
-        // Populate enhanced curation analysis
-        function populateCurationAnalysis(curation) {
-            const analysisContent = document.getElementById('curation-analysis-content');
+        // Populate enhanced analysis
+        function populateEnhancedAnalysis(curation) {
+            const analysisContent = document.getElementById('enhanced-analysis-content');
             
             // Determine readiness based on the detailed analysis content
             let readiness = 'Unknown';
@@ -1246,10 +1246,10 @@
             // If we have LLM analysis, use it to determine status
             if (curation && curation.readiness) {
                 if (curation.readiness === 'READY') {
-                    statusMessage = "This paper is ready for curation but not yet in BugSigDB.";
+                    statusMessage = "This paper has been analyzed and meets BugSigDB requirements.";
                     statusClass = 'status-ready';
                 } else if (curation.readiness === 'NOT_READY') {
-                    statusMessage = "This paper is not ready for curation. Missing required elements.";
+                    statusMessage = "This paper has been analyzed but requires additional review.";
                     statusClass = 'status-not-ready';
                 }
             } else {

--- a/frontend/paper-details.html
+++ b/frontend/paper-details.html
@@ -772,33 +772,33 @@
         }
 
         // Populate enhanced analysis
-        function populateEnhancedAnalysis(curation) {
+        function populateEnhancedAnalysis(analysis) {
             const analysisContent = document.getElementById('enhanced-analysis-content');
             
-            // Determine readiness based on the detailed analysis content
-            let readiness = 'Unknown';
-            let readinessClass = 'info';
+            // Determine status based on the detailed analysis content
+            let status = 'Unknown';
+            let statusClass = 'info';
             
-            // Check if the readiness assessment is consistent with the explanation
-            if (curation.readiness) {
-                readiness = curation.readiness;
+            // Check if the status assessment is consistent with the explanation
+            if (analysis.status) {
+                status = analysis.status;
                 
-                // Additional check: if explanation mentions "review article" or "not suitable", override readiness
-                if (curation.explanation && (
-                    curation.explanation.toLowerCase().includes('review article') ||
-                    curation.explanation.toLowerCase().includes('not suitable') ||
-                    curation.explanation.toLowerCase().includes('lacks specific') ||
-                    curation.explanation.toLowerCase().includes('no original research')
+                // Additional check: if explanation mentions "review article" or "not suitable", override status
+                if (analysis.explanation && (
+                    analysis.explanation.toLowerCase().includes('review article') ||
+                    analysis.explanation.toLowerCase().includes('not suitable') ||
+                    analysis.explanation.toLowerCase().includes('lacks specific') ||
+                    analysis.explanation.toLowerCase().includes('no original research')
                 )) {
-                    readiness = 'NOT_READY';
+                    status = 'REVIEW_REQUIRED';
                 }
                 
-                if (readiness === 'READY') {
-                    readinessClass = 'success';
-                } else if (readiness === 'NOT_READY') {
-                    readinessClass = 'warning';
-                } else if (readiness === 'ERROR') {
-                    readinessClass = 'danger';
+                if (status === 'COMPLETE') {
+                    statusClass = 'success';
+                } else if (status === 'REVIEW_REQUIRED') {
+                    statusClass = 'warning';
+                } else if (status === 'ERROR') {
+                    statusClass = 'danger';
                 }
             }
             
@@ -811,16 +811,16 @@
                                 ${readiness}
                             </span>
                         </p>
-                        <p><strong>Microbial Signatures:</strong> ${curation.microbial_signatures || 'Unknown'}</p>
-                        <p><strong>Data Quality:</strong> ${curation.data_quality || 'Unknown'}</p>
-                        <p><strong>Statistical Significance:</strong> ${curation.statistical_significance || 'Unknown'}</p>
-                        <p><strong>Data Completeness:</strong> ${curation.data_completeness || 'Unknown'}</p>
+                        <p><strong>Microbial Signatures:</strong> ${analysis.microbial_signatures || 'Unknown'}</p>
+                        <p><strong>Data Quality:</strong> ${analysis.data_quality || 'Unknown'}</p>
+                        <p><strong>Statistical Significance:</strong> ${analysis.statistical_significance || 'Unknown'}</p>
+                        <p><strong>Data Completeness:</strong> ${analysis.data_completeness || 'Unknown'}</p>
                     </div>
                     <div class="col-md-6">
                         <h3><i class="fas fa-chart-line"></i>Factor-Based Analysis</h3>
                         <div class="factor-analysis">
                             <p><strong>Factor-Based Score:</strong> 
-                                <span class="badge bg-primary">${Math.round((curation.factor_based_score || 0) * 100)}%</span>
+                                <span class="badge bg-primary">${Math.round((analysis.factor_based_score || 0) * 100)}%</span>
                             </p>
                             
                             <!-- General Factors -->
@@ -1187,7 +1187,7 @@
         function generateReportContent(data, pmid) {
             const metadata = data.metadata || {};
             const analysis = data.analysis || {};
-            const curation = analysis.curation_analysis || {};
+            const enhancedAnalysis = analysis.enhanced_analysis || {};
             
             if (!metadata.title) throw new Error('Paper title is missing from metadata');
             
@@ -1238,95 +1238,95 @@
                 </div>`;
             }
             
-            // Add Curation Status
-            // Use LLM readiness as primary source of truth for consistency
-            let statusMessage = data.curation_status_message || 'Unknown';
+            // Add Analysis Status
+            // Use LLM status as primary source of truth for consistency
+            let statusMessage = data.analysis_status_message || 'Unknown';
             let statusClass = 'status-unknown';
             
             // If we have LLM analysis, use it to determine status
-            if (curation && curation.readiness) {
-                if (curation.readiness === 'READY') {
+            if (analysis && analysis.status) {
+                if (analysis.status === 'COMPLETE') {
                     statusMessage = "This paper has been analyzed and meets BugSigDB requirements.";
-                    statusClass = 'status-ready';
-                } else if (curation.readiness === 'NOT_READY') {
+                    statusClass = 'status-complete';
+                } else if (analysis.status === 'REVIEW_REQUIRED') {
                     statusMessage = "This paper has been analyzed but requires additional review.";
-                    statusClass = 'status-not-ready';
+                    statusClass = 'status-review';
                 }
             } else {
                 // Fallback to the original logic
-                statusClass = data.curation_status_message?.toLowerCase().includes('ready') ? 'status-ready' : 
-                             data.curation_status_message?.toLowerCase().includes('not ready') ? 'status-not-ready' : 
-                             data.curation_status_message?.toLowerCase().includes('curated') ? 'status-curated' : 'status-unknown';
+                statusClass = data.analysis_status_message?.toLowerCase().includes('complete') ? 'status-complete' : 
+                             data.analysis_status_message?.toLowerCase().includes('review') ? 'status-review' : 
+                             data.analysis_status_message?.toLowerCase().includes('analyzed') ? 'status-analyzed' : 'status-unknown';
             }
             
             content += `<div class="highlight-box">
-                <h2>📋 Curation Status</h2>
+                <h2>📋 Analysis Status</h2>
                 <p><strong>Status:</strong> <span class="status-badge ${statusClass}">${statusMessage}</span></p>
                 <p><strong>Host:</strong> ${metadata.host || 'Not specified'}</p>
                 <p><strong>Body Site:</strong> ${metadata.body_site || 'Not specified'}</p>
                 <p><strong>Sequencing Type:</strong> ${metadata.sequencing_type || 'Not specified'}</p>
             </div>`;
             
-            // Add Enhanced Curation Analysis
-            if (curation && Object.keys(curation).length > 0) {
-                const readinessClass = curation.readiness === 'READY' ? 'status-ready' : 
-                                     curation.readiness === 'NOT_READY' ? 'status-not-ready' : 'status-unknown';
+            // Add Enhanced Analysis
+            if (analysis && Object.keys(analysis).length > 0) {
+                const statusClass = analysis.status === 'COMPLETE' ? 'status-complete' : 
+                                  analysis.status === 'REVIEW_REQUIRED' ? 'status-review' : 'status-unknown';
                 
                 content += `<div class="section">
-                    <h2>🔬 Enhanced Curation Analysis</h2>
+                    <h2>🔬 Enhanced Analysis</h2>
                     <div class="highlight-box">
-                        <p><strong>Readiness:</strong> <span class="status-badge ${readinessClass}">${curation.readiness || 'Unknown'}</span></p>
-                        <p><strong>Microbial Signatures:</strong> ${curation.microbial_signatures || 'Unknown'}</p>
-                        <p><strong>Data Quality:</strong> ${curation.data_quality || 'Unknown'}</p>
-                        <p><strong>Statistical Significance:</strong> ${curation.statistical_significance || 'Unknown'}</p>
-                        <p><strong>Data Completeness:</strong> ${curation.data_completeness || 'Unknown'}</p>
+                        <p><strong>Status:</strong> <span class="status-badge ${statusClass}">${analysis.status || 'Unknown'}</span></p>
+                        <p><strong>Microbial Signatures:</strong> ${analysis.microbial_signatures || 'Unknown'}</p>
+                        <p><strong>Data Quality:</strong> ${analysis.data_quality || 'Unknown'}</p>
+                        <p><strong>Statistical Significance:</strong> ${analysis.statistical_significance || 'Unknown'}</p>
+                        <p><strong>Data Completeness:</strong> ${analysis.data_completeness || 'Unknown'}</p>
                     </div>`;
                 
                 // Add Factor-Based Analysis
-                if (curation.factor_based_score !== undefined) {
-                    const factorScore = Math.round((curation.factor_based_score || 0) * 100);
+                if (analysis.factor_based_score !== undefined) {
+                    const factorScore = Math.round((analysis.factor_based_score || 0) * 100);
                     content += `<div class="highlight-box">
                         <h3>Factor-Based Analysis</h3>
                         <p><strong>Factor-Based Score:</strong> ${factorScore}%</p>
                         
-                        <h4>General Factors (${(curation.general_factors_present || []).length}/6)</h4>
-                        <p>${(curation.general_factors_present || []).length > 0 ? 
-                            curation.general_factors_present.join(', ') : 'No general factors identified'}</p>
+                        <h4>General Factors (${(analysis.general_factors_present || []).length}/6)</h4>
+                        <p>${(analysis.general_factors_present || []).length > 0 ? 
+                            analysis.general_factors_present.join(', ') : 'No general factors identified'}</p>
                         
-                        <h4>Human/Animal Factors (${(curation.human_animal_factors_present || []).length}/5)</h4>
-                        <p>${(curation.human_animal_factors_present || []).length > 0 ? 
-                            curation.human_animal_factors_present.join(', ') : 'No human/animal factors identified'}</p>
+                        <h4>Human/Animal Factors (${(analysis.human_animal_factors_present || []).length}/5)</h4>
+                        <p>${(analysis.human_animal_factors_present || []).length > 0 ? 
+                            analysis.human_animal_factors_present.join(', ') : 'No human/animal factors identified'}</p>
                         
-                        <h4>Environmental Factors (${(curation.environmental_factors_present || []).length}/5)</h4>
-                        <p>${(curation.environmental_factors_present || []).length > 0 ? 
-                            curation.environmental_factors_present.join(', ') : 'No environmental factors identified'}</p>
+                        <h4>Environmental Factors (${(analysis.environmental_factors_present || []).length}/5)</h4>
+                        <p>${(analysis.environmental_factors_present || []).length > 0 ? 
+                            analysis.environmental_factors_present.join(', ') : 'No environmental factors identified'}</p>
                         
                         <h4>Missing Critical Factors</h4>
-                        <p>${(curation.missing_critical_factors || []).length > 0 ? 
-                            curation.missing_critical_factors.join(', ') : 'No critical factors missing'}</p>
+                        <p>${(analysis.missing_critical_factors || []).length > 0 ? 
+                            analysis.missing_critical_factors.join(', ') : 'No critical factors missing'}</p>
                     </div>`;
                 }
                 
                 // Add Signature Types
-                if (curation.signature_types && curation.signature_types.length > 0) {
+                if (analysis.signature_types && analysis.signature_types.length > 0) {
                     content += `<div class="highlight-box">
                         <h3>Signature Types</h3>
-                        <p>${curation.signature_types.join(', ')}</p>
+                        <p>${analysis.signature_types.join(', ')}</p>
                     </div>`;
                 }
                 
-                if (curation.explanation) {
+                if (analysis.explanation) {
                     content += `<div class="highlight-box">
                         <h3>Detailed Explanation</h3>
-                        <p>${curation.explanation}</p>
+                        <p>${analysis.explanation}</p>
                     </div>`;
                 }
                 
-                if (curation.specific_reasons && curation.specific_reasons.length > 0) {
+                if (analysis.specific_reasons && analysis.specific_reasons.length > 0) {
                     content += `<div class="highlight-box">
                         <h3>Specific Reasons</h3>
                         <ul>`;
-                    curation.specific_reasons.forEach(reason => {
+                    analysis.specific_reasons.forEach(reason => {
                         content += `<li>${reason}</li>`;
                     });
                     content += `</ul></div>`;
@@ -1424,7 +1424,7 @@
             
             content += `<div class="footer">
                 <p>Generated by BugSigDB Analyzer - Advanced AI-powered paper analysis</p>
-                <p>Report includes comprehensive curation assessment, key findings, and research recommendations</p>
+                                        <p>Report includes comprehensive analysis assessment, key findings, and research recommendations</p>
             </div>`;
             
             return content;
@@ -1628,7 +1628,7 @@
     
     <div class="header">
         <h1>BugSigDB Analyzer Report</h1>
-        <div class="subtitle">Advanced AI-powered paper analysis and curation assessment</div>
+                        <div class="subtitle">Advanced AI-powered paper analysis and assessment</div>
         <div class="subtitle">Generated on ${new Date().toLocaleDateString()} at ${new Date().toLocaleTimeString()}</div>
     </div>
     

--- a/frontend/pdf-test.html
+++ b/frontend/pdf-test.html
@@ -187,8 +187,8 @@
                         </div>
 
                         <div style="background: #f8f9fa; padding: 20px; border-radius: 8px; margin-bottom: 25px;">
-                            <h2 style="color: #0d6efd; margin-bottom: 15px;">📋 Curation Status</h2>
-                            <p><strong>Status:</strong> Ready for Curation</p>
+                            <h2 style="color: #0d6efd; margin-bottom: 15px;">📋 Analysis Status</h2>
+                            <p><strong>Status:</strong> Analysis Complete</p>
                             <p><strong>Host:</strong> Human</p>
                             <p><strong>Body Site:</strong> Gastrointestinal</p>
                             <p><strong>Sequencing Type:</strong> 16S rRNA</p>


### PR DESCRIPTION
The core "`Ready for Curation`" messaging has been successfully removed from the user interface, and users will now see "`Analyze Papers`" and "`Analysis Status`" instead of curation-related terminology.

Closes: #27